### PR TITLE
croak on error

### DIFF
--- a/lib/Audio/Chromaprint.pm
+++ b/lib/Audio/Chromaprint.pm
@@ -90,7 +90,7 @@ has 'cp' => (
         if ( $self->has_silence_threshold ) {
             _set_option(
                 $cp, 'silence_threshold' => $self->silence_threshold,
-            );
+            ) or croak('error setting option silence_threshold');
         }
 
         return $cp;
@@ -117,7 +117,8 @@ sub start {
     $num_channels =~ /^[12]$/xms
         or croak 'num_channels must be 1 or 2';
 
-    return _start( $self->cp, $sample_rate, $num_channels );
+    _start( $self->cp, $sample_rate, $num_channels )
+        or croak 'unable to start';
 }
 
 sub set_option {
@@ -137,25 +138,29 @@ sub set_option {
             or croak('silence_threshold option must be between 0 and 32767');
     }
 
-    return _set_option( $self->cp, $name => $value );
+    _set_option( $self->cp, $name => $value )
+        or croak("error setting option $name");
 }
 
 sub finish {
     my $self = shift;
-    return _finish( $self->cp );
+    _finish( $self->cp )
+        or croak("unable to finish");
 }
 
 sub get_fingerprint_hash {
     my $self = shift;
     my $hash;
-    _get_fingerprint_hash( $self->cp, \$hash );
+    _get_fingerprint_hash( $self->cp, \$hash )
+        or croak("unable to get fingerprint hash");
     return $hash;
 }
 
 sub get_fingerprint {
     my $self = shift;
     my $ptr;
-    _get_fingerprint($self->cp, \$ptr);
+    _get_fingerprint($self->cp, \$ptr)
+        or croak("unable to get fingerprint");
     my $str = _opaque_to_string($ptr);
     _dealloc($ptr);
     return $str;
@@ -165,7 +170,8 @@ sub get_raw_fingerprint {
     my $self = shift;
     my $ptr;
     my $size;
-    _get_raw_fingerprint($self->cp, \$ptr, \$size);
+    _get_raw_fingerprint($self->cp, \$ptr, \$size)
+        or croak("unable to get raw fingerprint");
     # not espeically fast, but need a cast with a variable length array
     my $fp = FFI::Platypus->new->cast('opaque' => "uint32[$size]", $ptr);
     _dealloc($ptr);
@@ -205,18 +211,21 @@ sub get_delay_ms {
 sub get_raw_fingerprint_size {
     my $self = shift;
     my $size;
-    _get_raw_fingerprint_size($self->cp, \$size);
+    _get_raw_fingerprint_size($self->cp, \$size)
+        or croak("unable to get raw fingerprint size");
     return $size;
 }
 
 sub clear_fingerprint {
     my $self = shift;
-    _clear_fingerprint($self->cp);
+    _clear_fingerprint($self->cp)
+        or croak("unable to clear fingerprint");
 }
 
 sub feed {
     my($self, $data) = @_;
-    return _feed($self->cp, $data, length($data) / BYTES_PER_SAMPLE);
+    _feed($self->cp, $data, length($data) / BYTES_PER_SAMPLE)
+        or corak("unable to feed");
 }
 
 sub DEMOLISH {


### PR DESCRIPTION
Some functions return an error code, and we could check for it.  Others have been coded in the Perl API to return a value, and there isn't a natural way to return the error code, and throwing an exception makes more sense.

I think it makes sense to just croak in both cases to provide a more consistent API.