### PR TITLE
use Alien::chromaprint as a fallback if system lib unavailable

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,7 +1,11 @@
 requires 'Moose' => '0';
 requires 'Carp'  => '0';
 requires 'FFI::Platypus' => '0.88';
-requires 'FFI::CheckLib' => '0';
+requires 'FFI::CheckLib' => '0.25';
+
+on 'configure' => sub {
+    requires 'FFI::CheckLib' => '0.25';
+};
 
 on 'test' => sub {
     requires 'Test::More' => '0.96';

--- a/dist.ini
+++ b/dist.ini
@@ -74,3 +74,6 @@ filename = README.mkdn
 encoding = bytes
 match    = ^t/data/.*\.raw$
 
+[DynamicPrereqs]
+-condition = ! do { use FFI::CheckLib qw( find_lib ); find_lib( lib => 'chromaprint' ) }
+-body = requires('Alien::chromaprint')

--- a/lib/Audio/Chromaprint.pm
+++ b/lib/Audio/Chromaprint.pm
@@ -53,7 +53,7 @@ sub BUILD {
         return $name;
     } );
 
-    $ffi->lib( find_lib_or_exit( 'lib' => 'chromaprint' ) );
+    $ffi->lib( find_lib_or_exit( 'lib' => 'chromaprint', alien => 'Alien::chromaprint' ) );
 
     $ffi->attach( $_, @{ $SUBS{$_} } )
         for keys %SUBS;


### PR DESCRIPTION
All of the fails on the cpantesters matrix was making me sad:

http://matrix.cpantesters.org/?dist=Audio-Chromaprint+0.001

This PR will add `Alien::chromaprint` as a dynamic prereq and use it IF the system libchromaprint isn't found.