### PR TITLE
Using a Moose Role for FFI

### DIFF
--- a/lib/Audio/Chromaprint.pm
+++ b/lib/Audio/Chromaprint.pm
@@ -87,18 +87,23 @@ sub ffi_subs_data {
 sub ffi_lib   {'chromaprint'}
 sub ffi_alien {'Alien::chromaprint'}
 
-after '_build_ffi' => sub {
+around '_build_ffi' => sub {
+    my $orig = shift;
     my $self = shift;
-    $self->_ffi->attach_cast( '_opaque_to_string' => opaque => 'string' );
+    my $ffi  = $self->$orig(@_);
+
+    $ffi->attach_cast( '_opaque_to_string' => opaque => 'string' );
 
     # Setting this mangler lets is omit the chromaprint_ prefix
     # from the attach call below, and the function names used
     # by perl
-    $self->_ffi->mangler( sub {
+    $ffi->mangler( sub {
         my $name = shift;
         $name =~ s/^_/chromaprint_/xms;
         return $name;
     } );
+
+    return $ffi;
 };
 
 sub get_version {

--- a/lib/Audio/Chromaprint.pm
+++ b/lib/Audio/Chromaprint.pm
@@ -102,6 +102,7 @@ after '_build_ffi' => sub {
 };
 
 sub get_version {
+    my $self = shift;
     return $self->ffi_sub('_get_version')->();
 }
 

--- a/lib/Audio/Chromaprint.pm
+++ b/lib/Audio/Chromaprint.pm
@@ -92,8 +92,6 @@ around '_build_ffi' => sub {
     my $self = shift;
     my $ffi  = $self->$orig(@_);
 
-    $ffi->attach_cast( '_opaque_to_string' => opaque => 'string' );
-
     # Setting this mangler lets is omit the chromaprint_ prefix
     # from the attach call below, and the function names used
     # by perl
@@ -164,7 +162,8 @@ sub get_fingerprint {
     my $ptr;
     $self->ffi_sub('_get_fingerprint')->($self->cp, \$ptr)
         or croak('Unable to get fingerprint (get_fingerprint)');
-    my $str = _opaque_to_string($ptr);
+
+    my $str = $self->ffi->cast( 'opaque' => 'string' => $ptr );
     $self->ffi_sub('_dealloc')->($ptr);
     return $str;
 }

--- a/lib/Audio/Chromaprint.pm
+++ b/lib/Audio/Chromaprint.pm
@@ -40,10 +40,10 @@ has 'cp' => (
         # subtract one from the algorithm so that
         # 1 maps to 2 maps to CHROMAPRINT_ALGORITHM_TEST2
         # (the latter has the value 1)
-        my $cp   = _new( $self->algorithm - 1 );
+        my $cp   = $self->ffi_sub('_new')->( $self->algorithm - 1 );
 
         if ( $self->has_silence_threshold ) {
-            _set_option(
+            $self->ffi_sub('_set_option')->(
                 $cp, 'silence_threshold' => $self->silence_threshold,
             ) or croak('Error setting option silence_threshold');
         }

--- a/lib/Audio/Chromaprint.pm
+++ b/lib/Audio/Chromaprint.pm
@@ -4,7 +4,6 @@ package Audio::Chromaprint;
 use Moose;
 use Carp qw< croak >;
 use FFI::Platypus 0.88;
-use FFI::CheckLib;
 use Moose::Util::TypeConstraints;
 
 # This is in three statement so we could support 5.6.0,

--- a/lib/Audio/Chromaprint.pm
+++ b/lib/Audio/Chromaprint.pm
@@ -3,7 +3,6 @@ package Audio::Chromaprint;
 
 use Moose;
 use Carp qw< croak >;
-use FFI::Platypus 0.88;
 use Moose::Util::TypeConstraints;
 
 # This is in three statement so we could support 5.6.0,
@@ -176,7 +175,7 @@ sub get_raw_fingerprint {
         or croak('Unable to get raw fingerprint (get_raw_fingerprint)');
 
     # not espeically fast, but need a cast with a variable length array
-    my $fp = FFI::Platypus->new->cast( 'opaque' => "uint32[$size]", $ptr );
+    my $fp = $self->ffi->cast( 'opaque' => "uint32[$size]", $ptr );
     $self->ffi_sub('_dealloc')->($ptr);
     return $fp;
 }

--- a/lib/MooseX/Role/FFI.pm
+++ b/lib/MooseX/Role/FFI.pm
@@ -46,10 +46,10 @@ sub _build_ffi {
 sub _build_ffi_subs_refs {
     my $self      = shift;
     my $ffi       = $self->_ffi;
-    my %subs_data = %{ $self->_ffi_subs_data };
+    my %subs_data = %{ $self->ffi_subs_data };
 
     my %subs_refs = map +(
-        $_ => $ffi->function( $_ => $subs_data{$_} )->sub_ref,
+        $_ => $ffi->function( $_ => @{ $subs_data{$_} } )->sub_ref,
     ), keys %subs_data;
 
     return \%subs_refs;
@@ -58,7 +58,7 @@ sub _build_ffi_subs_refs {
 sub BUILD {
     # FFI subs are lazy so they can happen after ffi creation
     # but we still want them created during instantiation
-    shift->ffi_subs_refs;
+    shift->_ffi_subs_refs;
 }
 
 no Moose::Role;

--- a/lib/MooseX/Role/FFI.pm
+++ b/lib/MooseX/Role/FFI.pm
@@ -2,8 +2,7 @@ package MooseX::Role::FFI;
 # ABSTRACT: Easily create interfaces to FFI functions with Moose roles
 
 use Moose::Role;
-
-use FFI::Platypus 0.88;
+use FFI::Platypus 0.89_01;
 use FFI::CheckLib;
 
 requires qw<
@@ -36,7 +35,7 @@ sub _build_ffi {
     $ffi->lib(
         find_lib_or_exit(
             'lib' => $self->ffi_lib,
-            $fallback ? ( alien => $fallback->() ) : (),
+            $fallback ? ( 'alien' => $fallback->() ) : (),
         )
     );
 

--- a/lib/MooseX/Role/FFI.pm
+++ b/lib/MooseX/Role/FFI.pm
@@ -1,0 +1,73 @@
+package MooseX::Role::FFI;
+# ABSTRACT: Easily create interfaces to FFI functions with Moose roles
+
+use Moose::Role;
+
+use FFI::Platypus 0.88;
+use FFI::CheckLib;
+
+requires qw<
+    ffi_subs_data
+    ffi_lib
+>;
+
+has 'ffi' => (
+    'is'       => 'ro',
+    'reader'   => '_ffi',
+    'init_arg' => undef,
+    'builder'  => '_build_ffi',
+);
+
+has 'ffi_subs_refs' => (
+    'is'       => 'ro',
+    'reader'   => '_ffi_subs_refs',
+    'init_arg' => undef,
+    'builder'  => '_build_ffi_subs_refs',
+    'lazy'     => 1,
+    'traits'   => ['Hash'],
+    'handles'  => { 'get' => 'ffi_sub' },
+);
+
+sub _build_ffi {
+    my $self     = shift;
+    my $ffi_data = $self->ffi_subs_data;
+    my $ffi_lib  = $self->ffi_lib;
+    my $ffi      = FFI::Platypus->new;
+
+    my $fallback = $self->can('ffi_alien');
+
+    $ffi->lib(
+        find_lib_or_exit(
+            'lib' => $ffi_lib,
+            $fallback ? ( alien => $fallback->() ) : (),
+        )
+    );
+
+    return $ffi;
+}
+
+sub _build_ffi_subs_refs {
+    my $self      = shift;
+    my $ffi       = $self->_ffi;
+    my %subs_data = %{ $self->_ffi_subs_data };
+
+    my %subs_refs = map +(
+        $_ => $ffi->function( $_ => $subs_data{$_} )->sub_ref,
+    ), keys %subs_data;
+
+    return \%subs_refs;
+}
+
+sub BUILD {
+    # FFI subs are lazy so they can happen after ffi creation
+    # but we still want them created during instantiation
+    shift->ffi_subs_refs;
+}
+
+no Moose::Role;
+
+1;
+
+__END__
+
+=head

--- a/lib/MooseX/Role/FFI.pm
+++ b/lib/MooseX/Role/FFI.pm
@@ -30,15 +30,12 @@ has 'ffi_subs_refs' => (
 
 sub _build_ffi {
     my $self     = shift;
-    my $ffi_data = $self->ffi_subs_data;
-    my $ffi_lib  = $self->ffi_lib;
     my $ffi      = FFI::Platypus->new;
-
     my $fallback = $self->can('ffi_alien');
 
     $ffi->lib(
         find_lib_or_exit(
-            'lib' => $ffi_lib,
+            'lib' => $self->ffi_lib,
             $fallback ? ( alien => $fallback->() ) : (),
         )
     );

--- a/lib/MooseX/Role/FFI.pm
+++ b/lib/MooseX/Role/FFI.pm
@@ -25,7 +25,7 @@ has 'ffi_subs_refs' => (
     'builder'  => '_build_ffi_subs_refs',
     'lazy'     => 1,
     'traits'   => ['Hash'],
-    'handles'  => { 'get' => 'ffi_sub' },
+    'handles'  => { 'ffi_sub' => 'get' },
 );
 
 sub _build_ffi {

--- a/t/audio_chromaprint.t
+++ b/t/audio_chromaprint.t
@@ -3,7 +3,7 @@ use warnings;
 use Test::More;
 use Audio::Chromaprint;
 
-note "version = ", Audio::Chromaprint->get_version;
+note "version = ", Audio::Chromaprint->new->get_version;
 
 my $cp = Audio::Chromaprint->new;
 isa_ok $cp, 'Audio::Chromaprint';


### PR DESCRIPTION
[The MooseX::Role::FFI is provided here to make the review of both
easier to do at the same time. It will be released separately if
we were to approve this PR.]

The MooseX::Role::FFI allows to specify the subroutine data and the
library name - as well as the fallback - as subroutines.

It will then generate the corresponding callback for each sub, which
can be reached via a method.

The `after` allows us to have direct access to the FFI object *before*
the callbacks are generated. (Which I think is when we need it for
the mangler to work, but I'm not sure.)

What I like about it:

* Metadata, the rest is generated.
* Alien support built-in.
* We don't need to have class-level variables (though we could change
  it to it instead of subroutines.)
* We don't need to check that it has been instantiated (like we do
  in _get_version and $HAS_SUBS)

What I don't like about it:

* We need to make another method call to get the callback, depsite
  it being a definition of the class, not the instance.
* If you have a typo in the callback name, you cannot catch it,
  because it's a string to retrieve it.

I'm not sure the benefits outweigh the drawbacks. I was thinking of
possibly providing *another* interface and saying "pick yours."